### PR TITLE
Client logger factory

### DIFF
--- a/src/Configuration/ClientConfiguration.cs
+++ b/src/Configuration/ClientConfiguration.cs
@@ -70,6 +70,14 @@ namespace MultiFactor.Ldap.Adapter.Configuration
         public string[] ActiveDirectory2FaBypassGroup { get; set; }
 
         public bool LoadActiveDirectoryNestedGroups { get; set; }
+        /// <summary>
+        /// Client Log Level
+        /// </summary>
+        public string LogLevel  { get; set; }
+        /// <summary>
+        /// Log Format
+        /// </summary>
+        public string LogFormat { get; set; }
 
         /// <summary>
         /// Username transfor rules

--- a/src/Configuration/ServiceConfiguration.cs
+++ b/src/Configuration/ServiceConfiguration.cs
@@ -13,6 +13,8 @@ using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using MultiFactor.Ldap.Adapter.Core;
+using Microsoft.Extensions.DependencyInjection;
+using MultiFactor.Ldap.Adapter.Core.Logging;
 
 namespace MultiFactor.Ldap.Adapter.Configuration
 {
@@ -297,6 +299,12 @@ namespace MultiFactor.Ldap.Adapter.Configuration
         {
             var appSettings = ConfigurationManager.AppSettings;
             return appSettings?["logging-format"];
+        }
+
+        public static string GetLogLevel()
+        {
+            var appSettings = ConfigurationManager.AppSettings;
+            return appSettings?["logging-level"];
         }
     }
 }

--- a/src/Configuration/ServiceConfiguration.cs
+++ b/src/Configuration/ServiceConfiguration.cs
@@ -72,6 +72,10 @@ namespace MultiFactor.Ldap.Adapter.Configuration
         /// Logging level
         /// </summary>
         public string LogLevel { get; set; }
+        /// <summary>
+        /// Logging Format
+        /// </summary>
+        public string LogFormat { get; set; }
 
         /// <summary>
         /// Certificate for TLS
@@ -184,6 +188,8 @@ namespace MultiFactor.Ldap.Adapter.Configuration
             var activeDirectory2FaBypassGroupSetting            = appSettings.Settings["active-directory-2fa-bypass-group"]?.Value;
             var bypassSecondFactorWhenApiUnreachableSetting     = appSettings.Settings["bypass-second-factor-when-api-unreachable"]?.Value;
             var loadActiveDirectoryNestedGroupsSettings         = appSettings.Settings["load-active-directory-nested-groups"]?.Value;
+            var logLevel                                        = appSettings.Settings["logging-level"]?.Value;
+            var logFormat                                       = appSettings.Settings["logging-format"]?.Value;
 
 
             if (string.IsNullOrEmpty(ldapServerSetting))
@@ -205,7 +211,7 @@ namespace MultiFactor.Ldap.Adapter.Configuration
                 LdapServer = ldapServerSetting,
                 MultifactorApiKey = multifactorApiKeySetting,
                 MultifactorApiSecret = multifactorApiSecretSetting,
-                LdapBaseDn = ldapBaseDnSetting,
+                LdapBaseDn = ldapBaseDnSetting 
             };
 
             if (!string.IsNullOrEmpty(serviceAccountsSetting))
@@ -257,6 +263,16 @@ namespace MultiFactor.Ldap.Adapter.Configuration
                 }
 
                 configuration.LoadActiveDirectoryNestedGroups = loadActiveDirectoryNestedGroups;
+            }
+
+            if(!string.IsNullOrEmpty(logLevel))
+            {
+                configuration.LogLevel = logLevel;
+            }
+
+            if(!string.IsNullOrEmpty(logLevel))
+            {
+                configuration.LogFormat = logFormat;
             }
 
             if(userNameTransformRulesSection != null)

--- a/src/Configuration/ServiceConfiguration.cs
+++ b/src/Configuration/ServiceConfiguration.cs
@@ -270,7 +270,7 @@ namespace MultiFactor.Ldap.Adapter.Configuration
                 configuration.LogLevel = logLevel;
             }
 
-            if(!string.IsNullOrEmpty(logLevel))
+            if(!string.IsNullOrEmpty(logFormat))
             {
                 configuration.LogFormat = logFormat;
             }

--- a/src/Core/ClientLoggerFactory.cs
+++ b/src/Core/ClientLoggerFactory.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MultiFactor.Ldap.Adapter.Configuration;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog;
+using System.IO;
+using ILogger = Serilog.ILogger;
+using Serilog.Formatting.Compact;
+using Serilog.Formatting;
+using System.Collections.Generic;
+
+namespace MultiFactor.Ldap.Adapter.Core
+{
+    public class ClientLoggerFactory
+    {
+        private readonly ILogger _globalLogger;
+        private Dictionary<string,  ILogger> _loggerMap = new Dictionary<string, ILogger>();
+        public ClientLoggerFactory(ILogger globalLogger)
+        {
+            _globalLogger = globalLogger;
+        }
+        
+        public ILogger GetLogger(ClientConfiguration configuration)
+        {
+            if(string.IsNullOrEmpty(configuration.LogLevel))
+            {
+                return _globalLogger;
+            }
+            if(!_loggerMap.ContainsKey(configuration.Name))
+            {
+                _loggerMap[configuration.Name] = CreateLogger(configuration);
+            }
+            return _loggerMap[configuration.Name];
+        }
+        
+        private ILogger CreateLogger(ClientConfiguration configuration)
+        {
+            var levelSwitch = new LoggingLevelSwitch(LogEventLevel.Information);
+            var loggerConfiguration = new LoggerConfiguration()
+                .MinimumLevel.ControlledBy(levelSwitch);
+
+            var formatter = GetLogFormatter(configuration);
+            if (formatter != null)
+            {
+                loggerConfiguration
+                    .WriteTo.Console(formatter)
+                    .WriteTo.File(formatter, $"{Core.Constants.ApplicationPath}logs{Path.DirectorySeparatorChar}log-.txt", rollingInterval: RollingInterval.Day);
+            }
+            else
+            {
+                loggerConfiguration
+                    .WriteTo.Console()
+                    .WriteTo.File($"{Core.Constants.ApplicationPath}logs{Path.DirectorySeparatorChar}log-.txt", rollingInterval: RollingInterval.Day);
+            }
+            SetLogLevel(configuration.LogLevel, levelSwitch);
+            var logger = loggerConfiguration.CreateLogger();
+            logger.Information($"Logging level {levelSwitch.MinimumLevel} for client {configuration.Name}");
+            return logger;
+        }
+
+        private ITextFormatter GetLogFormatter(ClientConfiguration configuration)
+        {
+            var format = configuration.LogFormat;
+            switch (format?.ToLower())
+            {
+                case "json":
+                    return new RenderedCompactJsonFormatter();
+                default:
+                    return null;
+            }
+        }
+
+        private void SetLogLevel(string level, LoggingLevelSwitch levelSwitch)
+        {
+            switch (level)
+            {
+                case "Debug":
+                    levelSwitch.MinimumLevel = LogEventLevel.Debug;
+                    break;
+                case "Info":
+                    levelSwitch.MinimumLevel = LogEventLevel.Information;
+                    break;
+                case "Warn":
+                    levelSwitch.MinimumLevel = LogEventLevel.Warning;
+                    break;
+                case "Error":
+                    levelSwitch.MinimumLevel = LogEventLevel.Error;
+                    break;
+            }
+        }
+    }
+}

--- a/src/Core/Logging/ClientLoggerProvider.cs
+++ b/src/Core/Logging/ClientLoggerProvider.cs
@@ -10,14 +10,13 @@ using Serilog.Formatting.Compact;
 using Serilog.Formatting;
 using System.Collections.Generic;
 
-namespace MultiFactor.Ldap.Adapter.Core
+namespace MultiFactor.Ldap.Adapter.Core.Logging
 {
-    public class ClientLoggerFactory
+    public class ClientLoggerProvider
     {
         private ILogger _globalLogger = null;
-        private LoggingLevelSwitch _globalLoggerLevelSwitch = null;
-        private Dictionary<string,  ILogger> _loggerMap = new Dictionary<string, ILogger>();
-       
+        private Dictionary<string, ILogger> _loggerMap = new Dictionary<string, ILogger>();
+
         public ILogger GetLogger(LoggingLevelSwitch loggingLevelSwitch)
         {
             if (_globalLogger == null)
@@ -29,18 +28,18 @@ namespace MultiFactor.Ldap.Adapter.Core
 
         public ILogger GetLogger(ClientConfiguration configuration)
         {
-            if(string.IsNullOrEmpty(configuration.LogLevel))
+            if (string.IsNullOrEmpty(configuration.LogLevel))
             {
                 return _globalLogger;
             }
-            if(!_loggerMap.ContainsKey(configuration.Name))
+            if (!_loggerMap.ContainsKey(configuration.Name))
             {
                 var levelSwitch = new LoggingLevelSwitch(LogEventLevel.Information);
                 _loggerMap[configuration.Name] = CreateLogger(configuration, levelSwitch);
             }
             return _loggerMap[configuration.Name];
         }
-        
+
         private ILogger CreateLogger(ClientConfiguration configuration, LoggingLevelSwitch levelSwitch)
         {
             var loggerConfiguration = new LoggerConfiguration()
@@ -51,21 +50,21 @@ namespace MultiFactor.Ldap.Adapter.Core
             {
                 loggerConfiguration
                     .WriteTo.Console(formatter)
-                    .WriteTo.File(formatter, $"{Core.Constants.ApplicationPath}logs{Path.DirectorySeparatorChar}log-.txt", rollingInterval: RollingInterval.Day);
+                    .WriteTo.File(formatter, $"{Constants.ApplicationPath}logs{Path.DirectorySeparatorChar}log-.txt", rollingInterval: RollingInterval.Day);
             }
             else
             {
                 loggerConfiguration
                     .WriteTo.Console()
-                    .WriteTo.File($"{Core.Constants.ApplicationPath}logs{Path.DirectorySeparatorChar}log-.txt", rollingInterval: RollingInterval.Day);
+                    .WriteTo.File($"{Constants.ApplicationPath}logs{Path.DirectorySeparatorChar}log-.txt", rollingInterval: RollingInterval.Day);
             }
             ILogger logger;
-            if(configuration != null)
+            if (configuration != null)
             {
                 SetLogLevel(configuration.LogLevel, levelSwitch);
                 logger = loggerConfiguration.CreateLogger();
                 logger.Information($"Logging level {levelSwitch.MinimumLevel} for client {configuration.Name}");
-            } 
+            }
             else
             {
                 logger = loggerConfiguration.CreateLogger();
@@ -75,7 +74,7 @@ namespace MultiFactor.Ldap.Adapter.Core
 
         private ITextFormatter GetLogFormatter(ClientConfiguration configuration)
         {
-            var format = (configuration == null) ? ServiceConfiguration.GetLogFormat() : configuration.LogFormat;
+            var format = configuration == null ? ServiceConfiguration.GetLogFormat() : configuration.LogFormat;
             switch (format?.ToLower())
             {
                 case "json":

--- a/src/Core/Logging/ClientLoggerProvider.cs
+++ b/src/Core/Logging/ClientLoggerProvider.cs
@@ -7,7 +7,7 @@ namespace MultiFactor.Ldap.Adapter.Core.Logging
 {
     public class ClientLoggerProvider
     {
-        private ConcurrentDictionary<string, ILogger> _loggerMap = new ConcurrentDictionary<string, ILogger>();
+        protected ConcurrentDictionary<string, ILogger> _loggerMap = new ConcurrentDictionary<string, ILogger>();
 
         public ILogger GetLogger(ClientConfiguration configuration)
         {

--- a/src/Core/Logging/ClientLoggerProvider.cs
+++ b/src/Core/Logging/ClientLoggerProvider.cs
@@ -1,106 +1,27 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using MultiFactor.Ldap.Adapter.Configuration;
-using Serilog.Core;
-using Serilog.Events;
-using Serilog;
-using System.IO;
+﻿using MultiFactor.Ldap.Adapter.Configuration;
 using ILogger = Serilog.ILogger;
-using Serilog.Formatting.Compact;
-using Serilog.Formatting;
 using System.Collections.Generic;
+using Serilog;
+using System.Collections.Concurrent;
 
 namespace MultiFactor.Ldap.Adapter.Core.Logging
 {
     public class ClientLoggerProvider
     {
-        private ILogger _globalLogger = null;
-        private Dictionary<string, ILogger> _loggerMap = new Dictionary<string, ILogger>();
-
-        public ILogger GetLogger(LoggingLevelSwitch loggingLevelSwitch)
-        {
-            if (_globalLogger == null)
-            {
-                _globalLogger = CreateLogger(null, loggingLevelSwitch);
-            }
-            return _globalLogger;
-        }
+        private ConcurrentDictionary<string, ILogger> _loggerMap = new ConcurrentDictionary<string, ILogger>();
 
         public ILogger GetLogger(ClientConfiguration configuration)
         {
             if (string.IsNullOrEmpty(configuration.LogLevel))
             {
-                return _globalLogger;
+                return Log.Logger;
             }
             if (!_loggerMap.ContainsKey(configuration.Name))
             {
-                var levelSwitch = new LoggingLevelSwitch(LogEventLevel.Information);
-                _loggerMap[configuration.Name] = CreateLogger(configuration, levelSwitch);
+                var logger = LoggerFactory.CreateLogger(configuration.LogFormat, configuration.LogLevel);
+                _loggerMap.TryAdd(configuration.Name, logger);
             }
             return _loggerMap[configuration.Name];
-        }
-
-        private ILogger CreateLogger(ClientConfiguration configuration, LoggingLevelSwitch levelSwitch)
-        {
-            var loggerConfiguration = new LoggerConfiguration()
-                .MinimumLevel.ControlledBy(levelSwitch);
-
-            var formatter = GetLogFormatter(configuration);
-            if (formatter != null)
-            {
-                loggerConfiguration
-                    .WriteTo.Console(formatter)
-                    .WriteTo.File(formatter, $"{Constants.ApplicationPath}logs{Path.DirectorySeparatorChar}log-.txt", rollingInterval: RollingInterval.Day);
-            }
-            else
-            {
-                loggerConfiguration
-                    .WriteTo.Console()
-                    .WriteTo.File($"{Constants.ApplicationPath}logs{Path.DirectorySeparatorChar}log-.txt", rollingInterval: RollingInterval.Day);
-            }
-            ILogger logger;
-            if (configuration != null)
-            {
-                SetLogLevel(configuration.LogLevel, levelSwitch);
-                logger = loggerConfiguration.CreateLogger();
-                logger.Information($"Logging level {levelSwitch.MinimumLevel} for client {configuration.Name}");
-            }
-            else
-            {
-                logger = loggerConfiguration.CreateLogger();
-            }
-            return logger;
-        }
-
-        private ITextFormatter GetLogFormatter(ClientConfiguration configuration)
-        {
-            var format = configuration == null ? ServiceConfiguration.GetLogFormat() : configuration.LogFormat;
-            switch (format?.ToLower())
-            {
-                case "json":
-                    return new RenderedCompactJsonFormatter();
-                default:
-                    return null;
-            }
-        }
-
-        public void SetLogLevel(string level, LoggingLevelSwitch levelSwitch)
-        {
-            switch (level)
-            {
-                case "Debug":
-                    levelSwitch.MinimumLevel = LogEventLevel.Debug;
-                    break;
-                case "Info":
-                    levelSwitch.MinimumLevel = LogEventLevel.Information;
-                    break;
-                case "Warn":
-                    levelSwitch.MinimumLevel = LogEventLevel.Warning;
-                    break;
-                case "Error":
-                    levelSwitch.MinimumLevel = LogEventLevel.Error;
-                    break;
-            }
         }
     }
 }

--- a/src/Core/Logging/ClientLoggerProvider.cs
+++ b/src/Core/Logging/ClientLoggerProvider.cs
@@ -1,6 +1,5 @@
 ﻿using MultiFactor.Ldap.Adapter.Configuration;
 using ILogger = Serilog.ILogger;
-using System.Collections.Generic;
 using Serilog;
 using System.Collections.Concurrent;
 

--- a/src/Core/Logging/LoggerFactory.cs
+++ b/src/Core/Logging/LoggerFactory.cs
@@ -1,0 +1,45 @@
+﻿using Serilog.Core;
+using Serilog;
+using System.IO;
+using ILogger = Serilog.ILogger;
+using Serilog.Formatting.Compact;
+using Serilog.Formatting;
+
+namespace MultiFactor.Ldap.Adapter.Core.Logging
+{
+    public class LoggerFactory
+    {
+        public ILogger CreateLogger(string logFormat, string logLevel, LoggingLevelSwitch levelSwitch)
+        {
+            var loggerConfiguration = new LoggerConfiguration()
+                .MinimumLevel.ControlledBy(levelSwitch);
+
+            var formatter = GetLogFormatter(logFormat);
+            if (formatter != null)
+            {
+                loggerConfiguration
+                    .WriteTo.Console(formatter)
+                    .WriteTo.File(formatter, $"{Constants.ApplicationPath}logs{Path.DirectorySeparatorChar}log-.txt", rollingInterval: RollingInterval.Day);
+            }
+            else
+            {
+                loggerConfiguration
+                    .WriteTo.Console()
+                    .WriteTo.File($"{Constants.ApplicationPath}logs{Path.DirectorySeparatorChar}log-.txt", rollingInterval: RollingInterval.Day);
+            }
+
+            return loggerConfiguration.CreateLogger();
+        }
+
+        private ITextFormatter GetLogFormatter(string format)
+        {
+            switch (format?.ToLower())
+            {
+                case "json":
+                    return new RenderedCompactJsonFormatter();
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/src/Core/Logging/LoggerFactory.cs
+++ b/src/Core/Logging/LoggerFactory.cs
@@ -4,15 +4,18 @@ using System.IO;
 using ILogger = Serilog.ILogger;
 using Serilog.Formatting.Compact;
 using Serilog.Formatting;
+using Serilog.Events;
 
 namespace MultiFactor.Ldap.Adapter.Core.Logging
 {
-    public class LoggerFactory
+    public static class LoggerFactory
     {
-        public ILogger CreateLogger(string logFormat, string logLevel, LoggingLevelSwitch levelSwitch)
+        public static ILogger CreateLogger(string logFormat, string logLevel)
         {
+            var levelSwitch = new LoggingLevelSwitch(LogEventLevel.Information);
+            levelSwitch.SetLogLevel(logLevel);
             var loggerConfiguration = new LoggerConfiguration()
-                .MinimumLevel.ControlledBy(levelSwitch);
+                           .MinimumLevel.ControlledBy(levelSwitch);
 
             var formatter = GetLogFormatter(logFormat);
             if (formatter != null)
@@ -31,7 +34,7 @@ namespace MultiFactor.Ldap.Adapter.Core.Logging
             return loggerConfiguration.CreateLogger();
         }
 
-        private ITextFormatter GetLogFormatter(string format)
+        private static ITextFormatter GetLogFormatter(string format)
         {
             switch (format?.ToLower())
             {

--- a/src/Core/Logging/LoggingLevelSwtichFactory.cs
+++ b/src/Core/Logging/LoggingLevelSwtichFactory.cs
@@ -1,0 +1,27 @@
+﻿using Serilog.Core;
+using Serilog.Events;
+
+namespace MultiFactor.Ldap.Adapter.Core.Logging
+{
+    public static class LoggingLevelSwtichFactory
+    {
+        public static void SetLogLevel(this LoggingLevelSwitch levelSwitch, string level)
+        {
+            switch (level)
+            {
+                case "Debug":
+                    levelSwitch.MinimumLevel = LogEventLevel.Debug;
+                    break;
+                case "Info":
+                    levelSwitch.MinimumLevel = LogEventLevel.Information;
+                    break;
+                case "Warn":
+                    levelSwitch.MinimumLevel = LogEventLevel.Warning;
+                    break;
+                case "Error":
+                    levelSwitch.MinimumLevel = LogEventLevel.Error;
+                    break;
+            }
+        }
+    }
+}

--- a/src/Core/TlsCertificateFactory.cs
+++ b/src/Core/TlsCertificateFactory.cs
@@ -1,0 +1,44 @@
+﻿using MultiFactor.Ldap.Adapter.Configuration;
+using MultiFactor.Ldap.Adapter.Services;
+using Serilog;
+using System.IO;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+
+namespace MultiFactor.Ldap.Adapter.Core
+{
+    public static class TlsCertificateFactory
+    {
+        public static void EnsureTlsCertificatesExist(string path, ServiceConfiguration configuration, ILogger logger)
+        {
+            var certDirectory = $"{path}tls";
+            if (!Directory.Exists(certDirectory))
+            {
+                Directory.CreateDirectory(certDirectory);
+            }
+
+            var certPath = $"{certDirectory}{Path.DirectorySeparatorChar}certificate.pfx";
+            if (!File.Exists(certPath))
+            {
+                var subj = Dns.GetHostEntry("").HostName;
+
+                logger.Debug($"Generating self-signing certificate for TLS with subject CN={subj}");
+
+                var certService = new CertificateService();
+                var cert = certService.GenerateCertificate(subj);
+
+                var data = cert.Export(X509ContentType.Pfx);
+                File.WriteAllBytes(certPath, data);
+
+                logger.Information($"Self-signed certificate with subject CN={subj} saved to {certPath}");
+
+                configuration.X509Certificate = cert;
+            }
+            else
+            {
+                logger.Debug($"Loading certificate for TLS from {certPath}");
+                configuration.X509Certificate = new X509Certificate2(certPath);
+            }
+        }
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MultiFactor.Ldap.Adapter.Configuration;
 using MultiFactor.Ldap.Adapter.Configuration.Core;
+using MultiFactor.Ldap.Adapter.Core;
 using MultiFactor.Ldap.Adapter.Server;
 using MultiFactor.Ldap.Adapter.Services;
 using MultiFactor.Ldap.Adapter.Services.Caching;
@@ -71,7 +72,7 @@ namespace MultiFactor.Ldap.Adapter
                 }
                 return serviceConf;
             });
-
+            services.AddSingleton<ClientLoggerFactory>();
             services.AddSingleton(prov => new RandomWaiter(prov.GetRequiredService<ServiceConfiguration>().InvalidCredentialDelay));
             services.AddSingleton<MultiFactorApiClient>();
             services.AddSingleton<LdapProxyFactory>();
@@ -82,6 +83,7 @@ namespace MultiFactor.Ldap.Adapter
             services.AddHostedService<ServerHost>();
         }
 
+ 
         private static LoggingLevelSwitch ConfigureLogging(IServiceCollection services)
         {
             var levelSwitch = new LoggingLevelSwitch(LogEventLevel.Information);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MultiFactor.Ldap.Adapter.Configuration;
 using MultiFactor.Ldap.Adapter.Configuration.Core;
-using MultiFactor.Ldap.Adapter.Core;
+using MultiFactor.Ldap.Adapter.Core.Logging;
 using MultiFactor.Ldap.Adapter.Server;
 using MultiFactor.Ldap.Adapter.Services;
 using MultiFactor.Ldap.Adapter.Services.Caching;
@@ -59,20 +59,17 @@ namespace MultiFactor.Ldap.Adapter
         {
             //create logging
             var loggingLevelSwitch = new LoggingLevelSwitch(LogEventLevel.Information);
-            services.AddSingleton<ClientLoggerFactory>();
-            services.AddSingleton(sp => { 
-                var logFactory = sp.GetRequiredService<ClientLoggerFactory>();
-                Log.Logger = logFactory.GetLogger(loggingLevelSwitch);
-                return Log.Logger;
-            });
+            services.AddSingleton<LoggerFactory>();
+            services.AddSingleton<ClientLoggerProvider>();
 
+            
             services.AddSingleton<IConfigurationProvider, ConfigurationProvider>();
             services.AddSingleton(sp => {
                 var configurationProvider = sp.GetRequiredService<IConfigurationProvider>();
                 var logger = sp.GetRequiredService<ILogger>();
-                var logFactory = sp.GetRequiredService<ClientLoggerFactory>();
+                var logFactory = sp.GetRequiredService<LoggerFactory>();
                 var serviceConf = new ServiceConfiguration(configurationProvider, logger);
-                logFactory.SetLogLevel(serviceConf.LogLevel, loggingLevelSwitch);
+                //slogFactory.SetLogLevel(serviceConf.LogLevel, loggingLevelSwitch);
                 if (serviceConf.ServerConfig.AdapterLdapsEndpoint != null)
                 {
                     GetOrCreateTlsCertificate(Core.Constants.ApplicationPath, serviceConf, Log.Logger);

--- a/src/Server/LdapProxy.cs
+++ b/src/Server/LdapProxy.cs
@@ -13,10 +13,8 @@ using System.IO;
 using System.Linq;
 using System.Net.Sockets;
 using System.Threading.Tasks;
-using System.Text.RegularExpressions;
 using MultiFactor.Ldap.Adapter.Server.LdapPacketModifiers;
 using MultiFactor.Ldap.Adapter.Core.Requests;
-using System.Collections.Generic;
 
 namespace MultiFactor.Ldap.Adapter.Server
 {

--- a/src/Server/LdapProxy.cs
+++ b/src/Server/LdapProxy.cs
@@ -356,7 +356,7 @@ namespace MultiFactor.Ldap.Adapter.Server
         private string SearchUserName(LdapAttribute attr)
         {
             var userNameAttrs = new[] { "cn", "uid", "samaccountname", "userprincipalname" };
-            var contextType = (LdapFilterChoice)attr.ContextType;
+            var contextType = (LdapFilterChoice?)attr.ContextType;
 
             if (contextType == LdapFilterChoice.equalityMatch)
             {

--- a/src/Services/LdapProxyFactory.cs
+++ b/src/Services/LdapProxyFactory.cs
@@ -1,6 +1,6 @@
 ﻿using MultiFactor.Ldap.Adapter.Configuration;
+using MultiFactor.Ldap.Adapter.Core;
 using MultiFactor.Ldap.Adapter.Server;
-using Serilog;
 using System.IO;
 using System.Net.Sockets;
 
@@ -9,20 +9,20 @@ namespace MultiFactor.Ldap.Adapter.Services
     public class LdapProxyFactory
     {
         private readonly MultiFactorApiClient _apiClient;
-        private readonly ILogger _logger;
+        private readonly ClientLoggerFactory _loggerProvider;
         private readonly RandomWaiter _randomWaiter;
 
-        public LdapProxyFactory(MultiFactorApiClient apiClient, ILogger logger,
+        public LdapProxyFactory(MultiFactorApiClient apiClient, ClientLoggerFactory loggerProvider,
             RandomWaiter randomWaiter)
         {
             _apiClient = apiClient;
-            _logger = logger;
+            _loggerProvider = loggerProvider;
             _randomWaiter = randomWaiter ?? throw new System.ArgumentNullException(nameof(randomWaiter));
         }
 
         public LdapProxy CreateProxy(TcpClient clientConn, Stream clientStream, TcpClient serverConn, Stream serverStream, ClientConfiguration clientConfig)
         {
-            return new LdapProxy(clientConn, clientStream, serverConn, serverStream, clientConfig, _apiClient, _randomWaiter, _logger);
+            return new LdapProxy(clientConn, clientStream, serverConn, serverStream, clientConfig, _apiClient, _randomWaiter, _loggerProvider.GetLogger(clientConfig));
         }
     }
 }

--- a/src/Services/LdapProxyFactory.cs
+++ b/src/Services/LdapProxyFactory.cs
@@ -1,5 +1,5 @@
 ﻿using MultiFactor.Ldap.Adapter.Configuration;
-using MultiFactor.Ldap.Adapter.Core;
+using MultiFactor.Ldap.Adapter.Core.Logging;
 using MultiFactor.Ldap.Adapter.Server;
 using System.IO;
 using System.Net.Sockets;
@@ -9,10 +9,10 @@ namespace MultiFactor.Ldap.Adapter.Services
     public class LdapProxyFactory
     {
         private readonly MultiFactorApiClient _apiClient;
-        private readonly ClientLoggerFactory _loggerProvider;
+        private readonly ClientLoggerProvider _loggerProvider;
         private readonly RandomWaiter _randomWaiter;
 
-        public LdapProxyFactory(MultiFactorApiClient apiClient, ClientLoggerFactory loggerProvider,
+        public LdapProxyFactory(MultiFactorApiClient apiClient, ClientLoggerProvider loggerProvider,
             RandomWaiter randomWaiter)
         {
             _apiClient = apiClient;
@@ -22,7 +22,15 @@ namespace MultiFactor.Ldap.Adapter.Services
 
         public LdapProxy CreateProxy(TcpClient clientConn, Stream clientStream, TcpClient serverConn, Stream serverStream, ClientConfiguration clientConfig)
         {
-            return new LdapProxy(clientConn, clientStream, serverConn, serverStream, clientConfig, _apiClient, _randomWaiter, _loggerProvider.GetLogger(clientConfig));
+            return new LdapProxy(
+                clientConn,
+                clientStream,
+                serverConn,
+                serverStream,
+                clientConfig,
+                _apiClient,
+                _randomWaiter,
+                _loggerProvider.GetLogger(clientConfig));
         }
     }
 }

--- a/tests/Assets/clients/client-minimal.config
+++ b/tests/Assets/clients/client-minimal.config
@@ -8,6 +8,8 @@
 	  <add key="ldap-server" value="ldap://domain.local"/>
 	  <add key="multifactor-nas-identifier" value="ddd"/>
 	  <add key="multifactor-shared-secret" value="test"/>
+	  <add key="logging-level" value="Warn"/>
+	  <add key="logging-format" value="json"/>
   </appSettings>
     <UserNameTransformRules>
 		<BeforeFirstFactor>

--- a/tests/LogLevelTest.cs
+++ b/tests/LogLevelTest.cs
@@ -1,13 +1,7 @@
-﻿
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using MultiFactor.Ldap.Adapter.Configuration;
-using MultiFactor.Ldap.Adapter.Core.Logging;
 using MultiFactor.Ldap.Adapter.Tests.Fixtures;
-using Serilog;
-using System;
-using System.Linq;
 using System.Net;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace MultiFactor.Ldap.Adapter.Tests
@@ -37,75 +31,16 @@ namespace MultiFactor.Ldap.Adapter.Tests
         }
 
         [Fact]
-        public void LoggerFactory_ShouldCreateLogger() 
+        public void ClientConfiguration_ShouldLoadLogLevelInSingleConfigMode()
         {
             var configuration = TestHostFactory.CreateHost(
-                  TestEnvironment.GetAssetPath(TestAssetLocation.RootDirectory, "app.config"),
-                  new[]
-                  {
-                        TestEnvironment.GetAssetPath(TestAssetLocation.ClientsDirectory, "client-minimal.config")
-                  }
+              TestEnvironment.GetAssetPath(TestAssetLocation.RootDirectory, "app.config"), 
+              new string[0]
             ).Services.GetRequiredService<ServiceConfiguration>();
 
-            var client = configuration.GetClient(IPAddress.Parse("127.0.0.2"));
-            var logger = LoggerFactory.CreateLogger(client.LogLevel, client.LogFormat);
-            Assert.NotNull(logger);
-            Assert.True(logger.IsEnabled(Serilog.Events.LogEventLevel.Warning));
-            Assert.False(logger.IsEnabled(Serilog.Events.LogEventLevel.Debug));
-        }
-
-
-
-        [Fact]
-        public void LoggerProvider_ShouldNotCreateLoggerTwice()
-        {
-            var configuration = TestHostFactory.CreateHost(
-                  TestEnvironment.GetAssetPath(TestAssetLocation.RootDirectory, "app.config"),
-                  new[]
-                  {
-                        TestEnvironment.GetAssetPath(TestAssetLocation.ClientsDirectory, "client-minimal.config")
-                  }
-            ).Services.GetRequiredService<ServiceConfiguration>();
-
-            var client = configuration.GetClient(IPAddress.Parse("127.0.0.2"));
-            var provider = new ClientLoggerProvider();
-            var logger = provider.GetLogger(client);
-            Assert.NotNull(logger);
-            var logger2 = provider.GetLogger(client);
-            Assert.True(logger == logger2);
-        }
-
-        [Fact]
-        public void LoggerProvider_ShouldBeConcurrent()
-        {
-            var configuration = TestHostFactory.CreateHost(
-                  TestEnvironment.GetAssetPath(TestAssetLocation.RootDirectory, "app.config"),
-                  new[]
-                  {
-                        TestEnvironment.GetAssetPath(TestAssetLocation.ClientsDirectory, "client-minimal.config")
-                  }
-            ).Services.GetRequiredService<ServiceConfiguration>();
-
-            var client = configuration.GetClient(IPAddress.Parse("127.0.0.2"));
-            var provider = new ClientLoggerProvider();
-            int arraySize = 200;
-            var bigArray = new ILogger[arraySize];
-            Array.Fill(bigArray, null);
-
-            Parallel.For(
-                0, arraySize,
-                new ParallelOptions()
-                {
-                    MaxDegreeOfParallelism = Environment.ProcessorCount,
-                },
-                (x) => bigArray[x] = provider.GetLogger(client)
-            );
-
-            for (int i = 0; i < arraySize - 1; i++)
-            {
-                Assert.True(bigArray[i] == bigArray[i + 1]);
-            }
-             
+            Assert.NotNull(configuration);
+            Assert.True(configuration.SingleClientMode);
+            Assert.Equal("Debug", configuration.LogLevel);
         }
     }
 }

--- a/tests/LogLevelTest.cs
+++ b/tests/LogLevelTest.cs
@@ -1,0 +1,57 @@
+﻿
+using Microsoft.Extensions.DependencyInjection;
+using MultiFactor.Ldap.Adapter.Configuration;
+using MultiFactor.Ldap.Adapter.Core;
+using MultiFactor.Ldap.Adapter.Tests.Fixtures;
+using System.Net;
+using Xunit;
+
+namespace MultiFactor.Ldap.Adapter.Tests
+{
+    public class LogLevelTest
+    {
+        [Fact]
+        public void ShouldLoad_ClientLogLevel() 
+        {
+            var configuration = TestHostFactory.CreateHost(
+              TestEnvironment.GetAssetPath(TestAssetLocation.RootDirectory, "app.config"),
+              new[]
+              {
+                    TestEnvironment.GetAssetPath(TestAssetLocation.ClientsDirectory, "client-minimal.config")
+              }
+            ).Services.GetRequiredService<ServiceConfiguration>();
+
+            Assert.NotNull(configuration);
+            Assert.False(configuration.SingleClientMode);
+
+            Assert.Equal("Debug", configuration.LogLevel);
+            Assert.Null(configuration.LogFormat);
+
+            var client = configuration.GetClient(IPAddress.Parse("127.0.0.2"));
+            Assert.Equal("Warn", client.LogLevel);
+            Assert.Equal("json", client.LogFormat);
+        }
+
+        [Fact]
+        public void ShouldLoad_CreateLoggingContext() 
+        {
+            var configuration = TestHostFactory.CreateHost(
+                  TestEnvironment.GetAssetPath(TestAssetLocation.RootDirectory, "app.config"),
+                  new[]
+                  {
+                        TestEnvironment.GetAssetPath(TestAssetLocation.ClientsDirectory, "client-minimal.config")
+                  }
+            ).Services.GetRequiredService<ServiceConfiguration>();
+
+            var client = configuration.GetClient(IPAddress.Parse("127.0.0.2"));
+            var provider = new ClientLoggerFactory(null);
+            var logger = provider.GetLogger(client);
+            Assert.NotNull(logger);
+            Assert.True(logger.IsEnabled(Serilog.Events.LogEventLevel.Warning));
+            Assert.False(logger.IsEnabled(Serilog.Events.LogEventLevel.Debug));
+        }
+    }
+
+
+
+}

--- a/tests/LogLevelTest.cs
+++ b/tests/LogLevelTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using MultiFactor.Ldap.Adapter.Configuration;
 using MultiFactor.Ldap.Adapter.Core;
+using MultiFactor.Ldap.Adapter.Core.Logging;
 using MultiFactor.Ldap.Adapter.Tests.Fixtures;
 using Serilog.Core;
 using System.Net;
@@ -12,7 +13,7 @@ namespace MultiFactor.Ldap.Adapter.Tests
     public class LogLevelTest
     {
         [Fact]
-        public void ShouldLoad_ClientLogLevel() 
+        public void RetrieveAndValidateLogger_NotNull_SingleClientModeFalse() 
         {
             var configuration = TestHostFactory.CreateHost(
               TestEnvironment.GetAssetPath(TestAssetLocation.RootDirectory, "app.config"),
@@ -34,7 +35,7 @@ namespace MultiFactor.Ldap.Adapter.Tests
         }
 
         [Fact]
-        public void ShouldLoad_CreateLoggingContext() 
+        public void CreateAndValidateLogger_NotNull_WarningEnabled_DebugDisabled() 
         {
             var configuration = TestHostFactory.CreateHost(
                   TestEnvironment.GetAssetPath(TestAssetLocation.RootDirectory, "app.config"),
@@ -45,8 +46,9 @@ namespace MultiFactor.Ldap.Adapter.Tests
             ).Services.GetRequiredService<ServiceConfiguration>();
 
             var client = configuration.GetClient(IPAddress.Parse("127.0.0.2"));
-            var provider = new ClientLoggerFactory();
-            var logger = provider.GetLogger(client);
+            var loggerFactory = new LoggerFactory();
+            var logLevelSwitch = new LoggingLevelSwitch();
+            var logger = loggerFactory.CreateLogger(client.LogLevel, client.LogFormat, logLevelSwitch);
             Assert.NotNull(logger);
             Assert.True(logger.IsEnabled(Serilog.Events.LogEventLevel.Warning));
             Assert.False(logger.IsEnabled(Serilog.Events.LogEventLevel.Debug));
@@ -66,11 +68,11 @@ namespace MultiFactor.Ldap.Adapter.Tests
             ).Services.GetRequiredService<ServiceConfiguration>();
 
             var client = configuration.GetClient(IPAddress.Parse("127.0.0.2"));
-            var provider = new ClientLoggerFactory();
-            var logger = provider.GetLogger(client);
-            Assert.NotNull(logger);
-            var logger2 = provider.GetLogger(client);
-            Assert.True(logger == logger2);
+            //var loggerFactory = new ClientLoggerFactory();
+            //var logger = provider.GetLogger(client);
+            //Assert.NotNull(logger);
+            //var logger2 = provider.GetLogger(client);
+            //Assert.True(logger == logger2);
         }
 
         [Fact]
@@ -85,12 +87,12 @@ namespace MultiFactor.Ldap.Adapter.Tests
             ).Services.GetRequiredService<ServiceConfiguration>();
 
             var client = configuration.GetClient(IPAddress.Parse("127.0.0.2"));
-            var provider = new ClientLoggerFactory();
-            var levelSwitch = new LoggingLevelSwitch();
-            var logger = provider.GetLogger(levelSwitch);
-            Assert.NotNull(logger);
-            var logger2 = provider.GetLogger(client);
-            Assert.True(logger != logger2);
+            //var loggerFactory = new ClientLoggerFactory();
+            //var levelSwitch = new LoggingLevelSwitch();
+            //var logger = provider.GetLogger(levelSwitch);
+            //Assert.NotNull(logger);
+            //var logger2 = provider.GetLogger(client);
+            //Assert.True(logger != logger2);
         }
     }
 }

--- a/tests/LogProviderTest.cs
+++ b/tests/LogProviderTest.cs
@@ -1,0 +1,70 @@
+﻿using MultiFactor.Ldap.Adapter.Configuration;
+using MultiFactor.Ldap.Adapter.Core.Logging;
+using System.Threading.Tasks;
+using System;
+using Xunit;
+using Serilog;
+
+namespace MultiFactor.Ldap.Adapter.Tests
+{
+    public class LogProviderTest
+    {
+        public static ClientConfiguration GetClientConfiguration(string logLevel = "Debug", string logFormat = "json")
+        {
+            return new ClientConfiguration()
+            {   
+                Name = "Client",
+                LogLevel = logLevel,
+                LogFormat = logFormat
+            };
+        }
+
+        [Fact]
+        public void LoggerFactory_ShouldCreateLogger()
+        {
+            var client = GetClientConfiguration("Warning", null);
+            var logger = LoggerFactory.CreateLogger(client.LogLevel, client.LogFormat);
+            Assert.NotNull(logger);
+            Assert.True(logger.IsEnabled(Serilog.Events.LogEventLevel.Warning));
+            Assert.False(logger.IsEnabled(Serilog.Events.LogEventLevel.Debug));
+        }
+
+
+        [Fact]
+        public void LoggerProvider_ShouldNotCreateLoggerTwice()
+        {
+            var client = GetClientConfiguration("Warning", null);
+
+            var provider = new ClientLoggerProvider();
+            var logger = provider.GetLogger(client);
+            Assert.NotNull(logger);
+            var logger2 = provider.GetLogger(client);
+            Assert.True(logger == logger2);
+        }
+
+        [Fact]
+        public void LoggerProvider_ShouldBeConcurrent()
+        {
+            var client = GetClientConfiguration("Warning", null);
+            var provider = new ClientLoggerProvider();
+            int arraySize = 200;
+            var bigArray = new ILogger[arraySize];
+            Array.Fill(bigArray, null);
+
+            Parallel.For(
+                0, arraySize,
+                new ParallelOptions()
+                {
+                    MaxDegreeOfParallelism = Math.Max(Environment.ProcessorCount - 1, 1),
+                },
+                (x) => bigArray[x] = provider.GetLogger(client)
+            );
+
+            for (int i = 1; i < arraySize; i++)
+            {
+                Assert.Same(bigArray[0], bigArray[i]);
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
### Release 20.07.2023 | Client-wide logging level
#### New
- Now you can specify logging level and format in a client' configuration file. Settings keys are same as it is in Web.config file:
   ```
   <add key="logging-level" value="Debug"/>
   <add key="logging-format" value="json"/>
   ```
   In case if logging level is not specified in the client' configuration file, the global one will be used.