### PR TITLE
Feature/dev-415-433

### DIFF
--- a/src/Configuration/ClientConfiguration.cs
+++ b/src/Configuration/ClientConfiguration.cs
@@ -117,5 +117,7 @@ namespace MultiFactor.Ldap.Adapter.Configuration
                 ActiveDirectory2FaGroup.Any() || 
                 ActiveDirectory2FaBypassGroup.Any();
         }
+        
+        public PrivacyModeDescriptor PrivacyModeDescriptor  { get; set; }
     }
 }

--- a/src/Configuration/PrivacyMode.cs
+++ b/src/Configuration/PrivacyMode.cs
@@ -1,0 +1,19 @@
+namespace MultiFactor.Ldap.Adapter.Configuration;
+
+public enum PrivacyMode
+{
+    /// <summary>
+    /// Include all
+    /// </summary>
+    None,
+    
+    /// <summary>
+    /// Disable all but identity
+    /// </summary>
+    Full,
+
+    /// <summary>
+    /// Disable all but identity and specified fields.
+    /// </summary>
+    Partial
+}

--- a/src/Configuration/PrivacyModeDescriptor.cs
+++ b/src/Configuration/PrivacyModeDescriptor.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+
+namespace MultiFactor.Ldap.Adapter.Configuration;
+
+public class PrivacyModeDescriptor
+{
+    private readonly string[] _fields;
+    public PrivacyMode Mode { get; }
+
+    public static PrivacyModeDescriptor Default => new(PrivacyMode.None);
+
+    public bool HasField(string field)
+    {
+        if (string.IsNullOrWhiteSpace(field))
+        {
+            return false;
+        }
+
+        return _fields.Any(x => x.Equals(field, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private PrivacyModeDescriptor(PrivacyMode mode, params string[] fields)
+    {
+        Mode = mode;
+        _fields = fields ?? throw new ArgumentNullException(nameof(fields));
+    }
+
+    public static PrivacyModeDescriptor Create(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return new PrivacyModeDescriptor(PrivacyMode.None);
+
+        var mode = GetMode(value);
+        if (mode != PrivacyMode.Partial) return new PrivacyModeDescriptor(mode);
+
+        var fields = GetFields(value);
+        return new PrivacyModeDescriptor(mode, fields);
+    }
+
+    private static PrivacyMode GetMode(string value)
+    {
+        var index = value.IndexOf(':');
+        if (index == -1)
+        {
+            if (!Enum.TryParse<PrivacyMode>(value, true, out var parsed1)) throw new Exception("Unexpected privacy-mode value");
+            return parsed1;
+        }
+
+        var sub = value[..index];
+        if (!Enum.TryParse<PrivacyMode>(sub, true, out var parsed2)) throw new Exception("Unexpected privacy-mode value");
+
+        return parsed2;
+    }
+
+    private static string[] GetFields(string value)
+    {
+        var index = value.IndexOf(':');
+        if (index == -1 || value.Length <= index + 1)
+        {
+            return Array.Empty<string>();
+        }
+
+        var sub = value[(index + 1)..];
+        return sub.Split(',', StringSplitOptions.RemoveEmptyEntries).Distinct().ToArray();
+    }
+}

--- a/src/Configuration/ServiceConfiguration.cs
+++ b/src/Configuration/ServiceConfiguration.cs
@@ -215,7 +215,8 @@ namespace MultiFactor.Ldap.Adapter.Configuration
             var logFormat                                       = appSettings.Settings["logging-format"]?.Value;
             var transformLdapIdentityString                          = appSettings.Settings["transform-ldap-identity"]?.Value;
             var ldapBindTimeout                                 = appSettings.Settings["ldap-bind-timeout"]?.Value;
-
+            var privacyMode                                     = appSettings.Settings["privacy-mode"]?.Value;
+            
             if (string.IsNullOrEmpty(ldapServerSetting))
             {
                 throw new Exception("Configuration error: 'ldap-server' element not found");
@@ -329,7 +330,8 @@ namespace MultiFactor.Ldap.Adapter.Configuration
                     configuration.LdapBindTimeout = bindTimeout;
                 }
             }
-
+            
+            configuration.PrivacyModeDescriptor = PrivacyModeDescriptor.Create(privacyMode);
             return configuration;
         }
 

--- a/src/Core/Logging/StartupLogger.cs
+++ b/src/Core/Logging/StartupLogger.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices.JavaScript;
+using Serilog;
+using Serilog.Core;
+using Serilog.Debugging;
+using Serilog.Events;
+
+namespace MultiFactor.Ldap.Adapter.Core.Logging;
+
+public static class StartupLogger
+{
+    private const string LogDirectory = "logs";
+    private const string StartupLogFile = "startup.log";
+    private const long FileSizeLimitBytes = 1024 * 1024 * 5;
+    private const string FileLogTemplate = "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff}|{Level:u3}|{SourceContext:l}] {Message:lj}{NewLine}{Exception}{Properties}{NewLine}";
+    private const string ConsoleLogTemplate = "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff}|{Level:u3}|{SourceContext:l}] {Message:lj}{NewLine}{Exception}{Properties}{NewLine}";
+
+    private static readonly Lazy<Logger> _logger = new(() =>
+    {
+        SelfLog.Enable(Console.WriteLine);
+
+        var baseDir = Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory);
+        var dir = Path.Combine(baseDir!, LogDirectory);
+        if (!Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        var path = Path.Combine(dir, StartupLogFile);
+        var loggerConfig = new LoggerConfiguration()
+            .WriteTo.File(path: path,
+                LogEventLevel.Verbose,
+                FileLogTemplate,
+                fileSizeLimitBytes: FileSizeLimitBytes,
+                rollOnFileSizeLimit: true)
+            .WriteTo.Console(LogEventLevel.Verbose, ConsoleLogTemplate)
+            .Enrich.FromLogContext();
+
+        return loggerConfig.CreateLogger();
+    });
+
+    /// <inheritdoc cref="Logger.Verbose"/>
+    public static void Verbose(string message, params object?[] values) => _logger.Value.Verbose(message, values);
+
+    /// <inheritdoc cref="System.Diagnostics.Debug"/>
+    public static void Debug(string message, params object?[] values) => _logger.Value.Debug(message, values);
+
+    /// <inheritdoc cref="Microsoft.VisualBasic.Information"/>
+    public static void Information(string message, params object?[] values) => _logger.Value.Information(message, values);
+
+    /// <inheritdoc cref="JSType.Error"/>
+    public static void Error(string message, params object?[] values) => _logger.Value.Error(message, values);
+
+    /// <inheritdoc cref="JSType.Error"/>
+    public static void Error(Exception ex, string message, params object?[] values) => _logger.Value.Error(ex, message, values);
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -34,15 +34,10 @@ namespace MultiFactor.Ldap.Adapter
             {
                 var errorMessage = FlattenException(ex);
 
-                if (Log.Logger != null)
-                {
-                    Log.Logger.Error($"Unable to start: {errorMessage}");
-                }
-                else
-                {
-                    Console.WriteLine($"Unable to start: {errorMessage}");
-                }
-
+                StartupLogger.Error(ex, "Unable to start: {Message:l}", errorMessage);
+            }
+            finally
+            {
                 host?.StopAsync();
             }
         }

--- a/src/Server/LdapProxy.cs
+++ b/src/Server/LdapProxy.cs
@@ -302,7 +302,8 @@ namespace MultiFactor.Ldap.Adapter.Server
                             }
                             
                             var connectedClient = new ConnectedClientInfo(_userName, _clientConfig);
-                            var result = await _apiClient.Authenticate(connectedClient); //second factor
+                            var personalData = new PersonalData(profile, _clientConfig.PrivacyModeDescriptor);
+                            var result = await _apiClient.Authenticate(connectedClient, personalData); //second factor
 
                             if (!result) // second factor failed
                             {

--- a/src/Services/LdapService.cs
+++ b/src/Services/LdapService.cs
@@ -106,6 +106,7 @@ namespace MultiFactor.Ldap.Adapter.Services
             attrList.ChildAttributes.Add(new LdapAttribute(UniversalDataType.OctetString, "UserPrincipalName"));
             attrList.ChildAttributes.Add(new LdapAttribute(UniversalDataType.OctetString, "DisplayName"));
             attrList.ChildAttributes.Add(new LdapAttribute(UniversalDataType.OctetString, "mail"));
+            attrList.ChildAttributes.Add(new LdapAttribute(UniversalDataType.OctetString, "email"));
             attrList.ChildAttributes.Add(new LdapAttribute(UniversalDataType.OctetString, "memberOf"));
 
             searchRequest.ChildAttributes.Add(attrList);
@@ -359,6 +360,7 @@ namespace MultiFactor.Ldap.Adapter.Services
                             case "userPrincipalName":
                                 profile.Upn = entry.Values.FirstOrDefault();
                                 break;
+                            case "email":
                             case "mail":
                                 profile.Email = entry.Values.FirstOrDefault();
                                 break;

--- a/src/Services/MultiFactorApiClient.cs
+++ b/src/Services/MultiFactorApiClient.cs
@@ -54,7 +54,7 @@ namespace MultiFactor.Ldap.Adapter.Services
             };
         }
 
-        public async Task<bool> Authenticate(ConnectedClientInfo connectedClient)
+        public async Task<bool> Authenticate(ConnectedClientInfo connectedClient, PersonalData personalData)
         {
             //try to get authenticated client to bypass second factor if configured
             if (_clientCache.TryHitCache(connectedClient.Username, connectedClient.ClientConfiguration))
@@ -67,6 +67,7 @@ namespace MultiFactor.Ldap.Adapter.Services
             var payload = new
             {
                 Identity = connectedClient.Username,
+                Email = personalData.Email
             };
 
             var response = await SendRequest(connectedClient.ClientConfiguration, url, payload);

--- a/src/Services/PersonalData.cs
+++ b/src/Services/PersonalData.cs
@@ -1,0 +1,28 @@
+using MultiFactor.Ldap.Adapter.Configuration;
+
+namespace MultiFactor.Ldap.Adapter.Services;
+
+public class PersonalData
+{
+    public string Email { get; private set; }
+
+    public PersonalData(LdapProfile userProfile, PrivacyModeDescriptor privacyModeDescriptor)
+    {
+        Email = userProfile.Email;
+        
+        switch (privacyModeDescriptor.Mode)
+        {
+            case PrivacyMode.Full:
+                Email = null;
+                break;
+            
+            case PrivacyMode.Partial:
+
+                if (!privacyModeDescriptor.HasField("Email"))
+                {
+                    Email = null;
+                }
+                break;
+        }
+    }
+}

--- a/tests/PersonalDataTests.cs
+++ b/tests/PersonalDataTests.cs
@@ -1,0 +1,41 @@
+using MultiFactor.Ldap.Adapter.Configuration;
+using MultiFactor.Ldap.Adapter.Services;
+using Xunit;
+
+namespace MultiFactor.Ldap.Adapter.Tests;
+
+public class PersonalDataTests
+{
+    [Fact]
+    public void CreatePersonalData_NonePrivacyMode_ShouldFillEmail()
+    {
+        var email = "email";
+        var descriptor = PrivacyModeDescriptor.Create(null);
+        var profile = new LdapProfile();
+        profile.Email = email;
+        var personalData = new PersonalData(profile, descriptor);
+        Assert.Equal(email, personalData.Email);
+    }
+    
+    [Fact]
+    public void CreatePersonalData_FullPrivacyMode_EmailShouldBeNull()
+    {
+        var email = "email";
+        var descriptor = PrivacyModeDescriptor.Create("Full");
+        var profile = new LdapProfile();
+        profile.Email = email;
+        var personalData = new PersonalData(profile, descriptor);
+        Assert.Null(personalData.Email);
+    }
+
+    [Fact]
+    public void CreatePersonalData_PartialPrivacyMode_ProvidedEmailNotNull()
+    {
+        var email = "email";
+        var descriptor = PrivacyModeDescriptor.Create($"Partial:Email");
+        var profile = new LdapProfile();
+        profile.Email = email;
+        var personalData = new PersonalData(profile, descriptor);
+        Assert.Equal(email, personalData.Email);
+    }
+}


### PR DESCRIPTION
### Release 24.02.2025 | Email attribute in API requests
#### New
- Now ldap adapter will send email attribute value in MF API request. If you don't want to send your email you should set `privacy-mode`.
- Added privacy mode functionality for email. The following setting remove Email from MF API request -`<add key="privacy-mode" value="Full"/>`
-   Added startup logger. Now startup errors are output to the console and written to the `startup.log` file. The file is located in the `logs` folder.